### PR TITLE
ArgumentOutOfRangeException when writing at specific addresses

### DIFF
--- a/Common/HybridStream.cs
+++ b/Common/HybridStream.cs
@@ -202,6 +202,9 @@ namespace Yextly.Common
             if (sourceOffset > endOffset)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
+            if (count == 0)
+                return;
+
             EnsureAvailablePagesFor(endOffset, true);
 
             var sourcePageIndex = GetPageIndex(sourceOffset, out var firstPageStartOffset);


### PR DESCRIPTION
Issuing a write operation with `count=0` (this is done by a library) has no consequences unless the current position is exactly a multiple of the page size.

For example, consider `initialLength=61046536`, `newLength=61046784` and `pageSize=16384`. In this case, issuing a write with `buffer=new byte[16]`, `offset=0` and `count=0` exhibits the error.

This is because `61046784 % 16384 == 0`, which correctly means that a new page must not be allocated, but on the other hand requires addressing the page `3726`, which is out of bounds.

Early exiting when the count is zero solves the issue.