### PR TITLE
Add single file application utilities

### DIFF
--- a/Common/GlobalSuppressions.cs
+++ b/Common/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Justification = "Discoverability purposes", Scope = "namespace", Target = "~N:System")]

--- a/Fx.sln
+++ b/Fx.sln
@@ -62,6 +62,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MocksUnitTests", "MocksUnit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mocks", "Mocks\Mocks.csproj", "{46C2A15D-8B37-4198-BFEC-9F4B30A4BBA1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptingServicesSFA", "ScriptingServicesSFA\ScriptingServicesSFA.csproj", "{1B4B8BAC-B6C3-4A5C-A15A-184C5DBCF9B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -156,6 +158,10 @@ Global
 		{46C2A15D-8B37-4198-BFEC-9F4B30A4BBA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{46C2A15D-8B37-4198-BFEC-9F4B30A4BBA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{46C2A15D-8B37-4198-BFEC-9F4B30A4BBA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B4B8BAC-B6C3-4A5C-A15A-184C5DBCF9B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B4B8BAC-B6C3-4A5C-A15A-184C5DBCF9B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B4B8BAC-B6C3-4A5C-A15A-184C5DBCF9B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B4B8BAC-B6C3-4A5C-A15A-184C5DBCF9B7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -173,6 +179,7 @@ Global
 		{211218E6-F779-4FFE-A09E-59CD476CC701} = {79D00295-3F24-4EFD-A2B3-405EE276B541}
 		{86C4780B-5628-4F34-9168-4C021732AEF3} = {7F2E8356-8B80-4849-A425-23F1898FC687}
 		{46C2A15D-8B37-4198-BFEC-9F4B30A4BBA1} = {7F2E8356-8B80-4849-A425-23F1898FC687}
+		{1B4B8BAC-B6C3-4A5C-A15A-184C5DBCF9B7} = {81F67124-3BCD-48DD-B976-824545A146A3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5E58D4F4-B5FD-4CE0-A8C5-C4AF7F4B2759}

--- a/ScriptingServicesSFA/GlobalSuppressions.cs
+++ b/ScriptingServicesSFA/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Justification = "Discoverability purposes", Scope = "namespace", Target = "~N:Yextly.Scripting.Abstractions")]

--- a/ScriptingServicesSFA/HashSetExtensions.cs
+++ b/ScriptingServicesSFA/HashSetExtensions.cs
@@ -1,0 +1,22 @@
+﻿// ==++==
+//
+//   Copyright (c) Shadowsoft Corporation.  All rights reserved.
+//
+// ==--==
+
+namespace Yextly.Scripting.Services.SingleFileApplication
+{
+    internal static class HashSetExtensions
+    {
+        public static void AddRange<T>(this HashSet<T> instance, IEnumerable<T> collection)
+        {
+            ArgumentNullException.ThrowIfNull(instance);
+            ArgumentNullException.ThrowIfNull(collection);
+
+            foreach (var item in collection)
+            {
+                instance.Add(item);
+            }
+        }
+    }
+}

--- a/ScriptingServicesSFA/MetadataReferenceCreator.cs
+++ b/ScriptingServicesSFA/MetadataReferenceCreator.cs
@@ -1,0 +1,75 @@
+﻿// ==++==
+//
+//   Copyright (c) Shadowsoft Corporation.  All rights reserved.
+//
+// ==--==
+
+using Microsoft.CodeAnalysis;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace Yextly.Scripting.Services.SingleFileApplication
+{
+    /// <summary>
+    /// Provides metadata creation utilities to work around the current limitation that the metadata is probed via Location instead.
+    /// </summary>
+    /// <remarks>Portion of this class comes from https://github.com/dotnet/runtime/issues/36590#issuecomment-689883856</remarks>
+    public static class MetadataReferenceCreator
+    {
+        /// <summary>
+        /// Creates a <see cref="MetadataReference"/> from the provided <see cref="Assembly"/> without using the problematic APIs when in SFA.
+        /// </summary>
+        /// <param name="assembly">The assembly whose metadata must be created from.</param>
+        /// <returns></returns>
+        /// <remarks>This method behaves differently depending on how the application is compiled: when not in SFA, you can reference every file-system backed assembly.
+        /// However, when in SFA, referencing an assembly not contained in the bundle throws an exception.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The metadata store does not contain the provided assembly.</exception>
+        public static MetadataReference CreateReference(Assembly assembly)
+        {
+            ArgumentNullException.ThrowIfNull(assembly);
+
+            var location = GetLocation(assembly);
+
+            if (location != null)
+            {
+                // Debugging, testing or normal publishing
+                return MetadataReference.CreateFromFile(location);
+            }
+
+            // This is the SFA execution flow
+            unsafe
+            {
+                if (!assembly.TryGetRawMetadata(out byte* blob, out int length))
+                    throw new InvalidOperationException($"Failed to access the metadata store for {assembly.FullName}.");
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+                // We suppress disposable warnings since we load these metadata only once
+                // and it is not clear what happens when the disposal occurs: are the inner pointers
+                // still pointing to what they should?
+                // The benefits of leaking them is clear in this case, therefore, at least for now, we leak them.
+
+                var moduleMetadata = ModuleMetadata.CreateFromMetadata((IntPtr)blob, length);
+                var assemblyMetadata = AssemblyMetadata.Create(moduleMetadata);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+                var metadataReference = assemblyMetadata.GetReference();
+                return metadataReference;
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is here for a reason: the suppression is enforced when publishing as a single file application.")]
+        internal static string? GetLocation(Assembly assembly)
+        {
+            // We use a side effect here: when in SFA, Location is null. This tells us that we are likely in this scenario.
+#pragma warning disable IL3000
+            ArgumentNullException.ThrowIfNull(assembly);
+
+            if (string.IsNullOrEmpty(assembly.Location))
+                return null;
+            else
+                return assembly.Location;
+#pragma warning restore IL3000
+        }
+    }
+}

--- a/ScriptingServicesSFA/NaiveTypeLoader.cs
+++ b/ScriptingServicesSFA/NaiveTypeLoader.cs
@@ -1,0 +1,128 @@
+﻿// ==++==
+//
+//   Copyright (c) Shadowsoft Corporation.  All rights reserved.
+//
+// ==--==
+
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace Yextly.Scripting.Services.SingleFileApplication
+{
+    /// <summary>
+    /// Poor man reachability with side effects (the runtime loads the assemblies for us in the proper way).
+    /// </summary>
+    internal sealed class NaiveTypeLoader
+    {
+        private readonly HashSet<Assembly> _assemblies = [];
+        private readonly Queue<Type> _types = new();
+        private readonly HashSet<Type> _visitedTypes = [];
+
+        public NaiveTypeLoader()
+        {
+        }
+
+        public void AddKnownAssemblies(IEnumerable<Assembly> source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            _assemblies.AddRange(source);
+        }
+
+        public void AddKnownAssembliesByName(IEnumerable<string> source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            _assemblies.AddRange(GetAssembliesFromString(source));
+        }
+
+        public void AddRootType(Type type)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+
+            Enqueue(type);
+        }
+
+        public ImmutableArray<Assembly> GetAssemblies()
+        {
+            // We sort for reproducibility purposes
+            return
+            [
+                .. _assemblies
+                    .OrderBy(x => x.FullName, StringComparer.Ordinal)
+            ];
+        }
+
+        public void Visit()
+        {
+            while (_types.TryDequeue(out var type))
+            {
+                foreach (var item in type.GetRuntimeProperties())
+                {
+                    Enqueue(item.PropertyType);
+                }
+
+                foreach (var item in type.GetRuntimeMethods())
+                {
+                    Enqueue(item.ReturnType);
+
+                    foreach (var p in item.GetParameters())
+                    {
+                        Enqueue(p.ParameterType);
+                    }
+                }
+
+                foreach (var item in type.GetInterfaces())
+                {
+                    Enqueue(item);
+                }
+
+                if (type.BaseType != null)
+                    Enqueue(type.BaseType);
+
+                if (type.IsGenericTypeParameter)
+                {
+                    foreach (var item in type.GenericTypeArguments)
+                    {
+                        Enqueue(item);
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<Assembly> GetAssembliesFromString(IEnumerable<string> source)
+        {
+            var allAssemblies = new Dictionary<string, Assembly>(StringComparer.Ordinal);
+
+            foreach (var item in AppDomain.CurrentDomain.GetAssemblies().AsEnumerable())
+            {
+                var name = item.GetName().Name;
+                if (name != null)
+                    allAssemblies.TryAdd(name, item);
+            }
+
+            // https://stackoverflow.com/questions/23907305/roslyn-has-no-reference-to-system-runtime
+            foreach (var item in source)
+            {
+                if (allAssemblies.TryGetValue(item, out var assembly))
+                {
+                    yield return assembly;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Failed to find the assembly {item}.");
+                }
+            }
+        }
+
+        private void Enqueue(Type type)
+        {
+            _assemblies.Add(type.Assembly);
+
+            if (_visitedTypes.Add(type))
+            {
+                _types.Enqueue(type);
+            }
+        }
+    }
+}

--- a/ScriptingServicesSFA/ScriptingExecutionContextBuilderExtensions.cs
+++ b/ScriptingServicesSFA/ScriptingExecutionContextBuilderExtensions.cs
@@ -1,0 +1,65 @@
+﻿// ==++==
+//
+//   Copyright (c) Shadowsoft Corporation.  All rights reserved.
+//
+// ==--==
+
+using Yextly.Scripting.Services.SingleFileApplication;
+
+namespace Yextly.Scripting.Abstractions
+{
+    /// <summary>
+    /// Provides extensions for <see cref="IScriptingExecutionContextBuilder"/>.
+    /// </summary>
+    public static class ScriptingExecutionContextBuilderExtensions
+    {
+        /// <summary>
+        /// Adds the analysis-time types to the provided <see cref="IScriptingExecutionContextBuilder" />.
+        /// </summary>
+        /// <param name="builder">The builder receiving the type references.</param>
+        /// <param name="types">The scripting metadata descriptors.</param>
+        /// <returns></returns>
+        public static IScriptingExecutionContextBuilder AddAnalysisTypes(this IScriptingExecutionContextBuilder builder, ScriptingRuntimeTypes types)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(types);
+
+            var source = types.AnalysisTypes;
+
+            AddTypes(builder, source);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the compile-time types to the provided <see cref="IScriptingExecutionContextBuilder" />.
+        /// </summary>
+        /// <param name="builder">The builder receiving the type references.</param>
+        /// <param name="types">The scripting metadata descriptors.</param>
+        /// <returns></returns>
+        public static IScriptingExecutionContextBuilder AddCompilationTypes(this IScriptingExecutionContextBuilder builder, ScriptingRuntimeTypes types)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(types);
+
+            var source = types.CompilationTypes;
+
+            AddTypes(builder, source);
+
+            return builder;
+        }
+
+        private static void AddTypes(IScriptingExecutionContextBuilder builder, ScriptingRuntimeTypeInfo source)
+        {
+            foreach (var item in source.Assemblies)
+            {
+                builder.MetadataReferences.Add(MetadataReferenceCreator.CreateReference(item));
+            }
+
+            foreach (var item in source.Usings)
+            {
+                builder.Usings.Add(item);
+            }
+        }
+    }
+}

--- a/ScriptingServicesSFA/ScriptingRuntimeTypeInfo.cs
+++ b/ScriptingServicesSFA/ScriptingRuntimeTypeInfo.cs
@@ -1,0 +1,32 @@
+﻿// ==++==
+//
+//   Copyright (c) Shadowsoft Corporation.  All rights reserved.
+//
+// ==--==
+
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace Yextly.Scripting.Services.SingleFileApplication
+{
+    /// <summary>
+    /// Contains information about the types in the scripting engine.
+    /// </summary>
+    public sealed record ScriptingRuntimeTypeInfo
+    {
+        /// <summary>
+        /// Contains the list of consolidated assemblies that must be referenced.
+        /// </summary>
+        public required ImmutableArray<Assembly> Assemblies { get; init; }
+
+        /// <summary>
+        /// Contains the list of all the consolidated known types.
+        /// </summary>
+        public required ImmutableArray<Type> KnownTypes { get; init; }
+
+        /// <summary>
+        /// Contains the list of all the consolidated hardcoded using directive to inject.
+        /// </summary>
+        public required ImmutableArray<string> Usings { get; init; }
+    }
+}

--- a/ScriptingServicesSFA/ScriptingRuntimeTypes.cs
+++ b/ScriptingServicesSFA/ScriptingRuntimeTypes.cs
@@ -1,0 +1,24 @@
+﻿// ==++==
+//
+//   Copyright (c) Shadowsoft Corporation.  All rights reserved.
+//
+// ==--==
+
+namespace Yextly.Scripting.Services.SingleFileApplication
+{
+    /// <summary>
+    /// Contains the collection of all the types used both for analysis and compilation by the scripting engine.
+    /// </summary>
+    public sealed record ScriptingRuntimeTypes
+    {
+        /// <summary>
+        /// Contains the analysis-time types.
+        /// </summary>
+        public required ScriptingRuntimeTypeInfo AnalysisTypes { get; init; }
+
+        /// <summary>
+        /// Contains the compilation-time types.
+        /// </summary>
+        public required ScriptingRuntimeTypeInfo CompilationTypes { get; init; }
+    }
+}

--- a/ScriptingServicesSFA/ScriptingRuntimeTypesFactory.cs
+++ b/ScriptingServicesSFA/ScriptingRuntimeTypesFactory.cs
@@ -1,0 +1,147 @@
+﻿// ==++==
+//
+//   Copyright (c) Shadowsoft Corporation.  All rights reserved.
+//
+// ==--==
+
+namespace Yextly.Scripting.Services.SingleFileApplication
+{
+    /// <summary>
+    /// Provides a common factory to streamline the creation of the scripting types.
+    /// </summary>
+    public abstract class ScriptingRuntimeTypesFactory
+    {
+        /// <summary>
+        /// Creates the scripting types.
+        /// </summary>
+        /// <returns></returns>
+        public ScriptingRuntimeTypes CreateScriptingRuntimeTypes()
+        {
+            var analysisOnlyUsings = new List<string>();
+
+            AddAnalysisOnlyUsings(analysisOnlyUsings);
+
+            var knownTypes = new List<Type>();
+
+            var loader = new NaiveTypeLoader();
+
+            loader.AddKnownAssembliesByName(GetRuntimeAssemblies());
+
+            AddKnownTypes(knownTypes);
+
+            foreach (var item in knownTypes)
+            {
+                loader.AddRootType(item);
+            }
+
+            // This is to reference only the subset of things that are used for interacting with the provided root types.
+            // We want to do this in order to limit showing many useless things in the suggestions (when the analysis feature is used).
+            // Note that since we are running in the same AppDomain, the user will not see the suggestions for certain types,
+            // but will be able to reference and use whatever we have in the AppDomain. In CoreClr there is no AppDomain management
+            // therefore if you do not want this, you need to create an out of process executor.
+            loader.Visit();
+
+            var analysisAssemblies = loader.GetAssemblies();
+
+            var analysis = new ScriptingRuntimeTypeInfo
+            {
+                Assemblies = analysisAssemblies,
+                KnownTypes = [.. knownTypes],
+                Usings = [.. analysisOnlyUsings]
+            };
+
+            var compilationKnownTypes = new List<Type>();
+
+            AddCompilationTypeToAssembliesKnownTypes(compilationKnownTypes);
+
+            foreach (var item in compilationKnownTypes)
+            {
+                loader.AddRootType(item);
+            }
+
+            // Note that we cumulate the already loaded assemblies.
+            loader.Visit();
+
+            var compilationAssemblies = loader.GetAssemblies();
+
+            var compilation = new ScriptingRuntimeTypeInfo
+            {
+                Assemblies = compilationAssemblies,
+                KnownTypes = [.. knownTypes],
+                Usings = [],
+            };
+
+            return new ScriptingRuntimeTypes
+            {
+                AnalysisTypes = analysis,
+                CompilationTypes = compilation,
+            };
+        }
+
+        /// <summary>
+        /// Adds the using clauses during for the analysis phase.
+        /// </summary>
+        /// <param name="list">The list of currently available using clauses.</param>
+        protected abstract void AddAnalysisOnlyUsingsCore(IList<string> list);
+
+        /// <summary>
+        /// Adds the types used for inferring the assemblies to load at compile time.
+        /// </summary>
+        /// <param name="source"></param>
+        protected abstract void AddCompilationTypeToAssembliesKnownTypesCore(IList<Type> source);
+
+        /// <summary>
+        /// Adds the known types.
+        /// </summary>
+        /// <param name="knownTypes"></param>
+        protected abstract void AddKnownTypesCore(IList<Type> knownTypes);
+
+        /// <summary>
+        /// Gets the list of all the assemblies that represent the runtime and must be referenced.
+        /// </summary>
+        /// <returns></returns>
+        protected virtual IEnumerable<string> GetRuntimeAssemblies()
+        {
+            return
+            [
+                "System.Private.CoreLib",
+                "System.Runtime",
+                "System.Collections",
+                "System.Collections.Immutable",
+            ];
+        }
+
+        private void AddAnalysisOnlyUsings(List<string> list)
+        {
+            ArgumentNullException.ThrowIfNull(list);
+
+            AddAnalysisOnlyUsingsCore(list);
+        }
+
+        private void AddCompilationTypeToAssembliesKnownTypes(List<Type> source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            // Here we must add all the assemblies that we need in order to compile.
+            // We cannot rely on any automatism and inference of the scripting engine since
+            // it will use Assembly.Location for things that we do not provide explicitly
+            // and this does not allow the script to run when hosted in SFAs.
+
+            AddCompilationTypeToAssembliesKnownTypesCore(source);
+        }
+
+        /// <summary>
+        /// Types (and their containing namespaces) that the user can reference without adding "usings".
+        /// </summary>
+        /// <param name="knownTypes"></param>
+        private void AddKnownTypes(List<Type> knownTypes)
+        {
+            ArgumentNullException.ThrowIfNull(knownTypes);
+
+            knownTypes.Add(typeof(Enumerable));
+            knownTypes.Add(typeof(List<>));
+
+            AddKnownTypesCore(knownTypes);
+        }
+    }
+}

--- a/ScriptingServicesSFA/ScriptingServicesSFA.csproj
+++ b/ScriptingServicesSFA/ScriptingServicesSFA.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net9.0</TargetFrameworks>
+		<Nullable>enable</Nullable>
+		<RootNamespace>Yextly.Scripting.Services.SingleFileApplication</RootNamespace>
+		<AssemblyName>Yextly.Scripting.Services.SingleFileApplication</AssemblyName>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Description>Scripting engine services specifically for single file applications</Description>
+		<Authors>$(Company)</Authors>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<IsPackable>true</IsPackable>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="..\Shared\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="GitInfo">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\ScriptingAbstractions\ScriptingAbstractions.csproj" />
+	  <ProjectReference Include="..\ScriptingServices\ScriptingServices.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/ScriptingServicesUnitTests/Context1.cs
+++ b/ScriptingServicesUnitTests/Context1.cs
@@ -4,7 +4,7 @@
 //
 // ==--==
 
-namespace ScriptingServicesTests
+namespace ScriptingServicesUnitTests
 {
     internal sealed class Context1(int baseValue) : IContext1
     {

--- a/ScriptingServicesUnitTests/Context2.cs
+++ b/ScriptingServicesUnitTests/Context2.cs
@@ -4,7 +4,7 @@
 //
 // ==--==
 
-namespace ScriptingServicesTests
+namespace ScriptingServicesUnitTests
 {
     internal sealed class Context2 : IContext2
     {

--- a/ScriptingServicesUnitTests/EngineTests.cs
+++ b/ScriptingServicesUnitTests/EngineTests.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Yextly.Scripting.Abstractions;
 
-namespace ScriptingServicesTests
+namespace ScriptingServicesUnitTests
 {
     public sealed class EngineTests
     {

--- a/ScriptingServicesUnitTests/IContext1.cs
+++ b/ScriptingServicesUnitTests/IContext1.cs
@@ -4,7 +4,7 @@
 //
 // ==--==
 
-namespace ScriptingServicesTests
+namespace ScriptingServicesUnitTests
 {
     public interface IContext1
     {

--- a/ScriptingServicesUnitTests/IContext2.cs
+++ b/ScriptingServicesUnitTests/IContext2.cs
@@ -4,7 +4,7 @@
 //
 // ==--==
 
-namespace ScriptingServicesTests
+namespace ScriptingServicesUnitTests
 {
     public interface IContext2
     {

--- a/ScriptingServicesUnitTests/MultiplexedScriptingEngine.cs
+++ b/ScriptingServicesUnitTests/MultiplexedScriptingEngine.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Yextly.Scripting.Abstractions;
 
-namespace ScriptingServicesTests
+namespace ScriptingServicesUnitTests
 {
     internal sealed class MultiplexedScriptingEngine(IScriptingEngine inner, ScriptType scriptType) : IScriptingEngine
     {

--- a/ScriptingServicesUnitTests/MultiplexedScriptingEngineFactories.cs
+++ b/ScriptingServicesUnitTests/MultiplexedScriptingEngineFactories.cs
@@ -7,7 +7,7 @@
 using Yextly.Scripting.Abstractions;
 using Yextly.Scripting.Services;
 
-namespace ScriptingServicesTests
+namespace ScriptingServicesUnitTests
 {
     internal sealed class MultiplexedScriptingEngineFactories(ScriptType scriptType) : IScriptingEngineFactories
     {

--- a/ScriptingServicesUnitTests/ScriptType.cs
+++ b/ScriptingServicesUnitTests/ScriptType.cs
@@ -4,7 +4,7 @@
 //
 // ==--==
 
-namespace ScriptingServicesTests
+namespace ScriptingServicesUnitTests
 {
     public enum ScriptType
     {


### PR DESCRIPTION
This PR introduce a reduced and engineered (not yet polished) set of utilities that work around the creation of the required metadata used by the Roslyn compiler when hosted in a single file application.  